### PR TITLE
Update exposing info

### DIFF
--- a/what-is-pair.org
+++ b/what-is-pair.org
@@ -33,11 +33,13 @@ The services that are pre-installed on the cluster are a combination of ones:
 ** Services chosen by the Pair Team
 All new clusters on Pair come with:
 - Domain name management and TLS Support ::
-  Pair will auto-expose any process listening on a port on all interfaces. This
+  Pair will auto-expose any process listening on a TCP or UDP port on all interfaces. This
   means any exposed cluster service is given a recognizable, sharable url. These
   URLs all follow the same naming pattern: if I create a pair instance named
   'cool', then all services I expose on that instance will have a url of
-  ~{SERVICENAME}.cool.pair.sharing.io~
+  ~{SERVICENAME}.cool.pair.sharing.io~.
+  Additionally with the exposing of services, each TCP/UDP service will be exposed
+  on the instance's IP address by the listening port.
 - Prometheus and Grafana ::
   These are dashboards for observing the health and activity of the cluster,
   viewable at ~prometheus.cool.pair.sharing.io~ and


### PR DESCRIPTION
I realised that there was a detail on the exposing missing.

I am trying to articulate the following:
Processes listening on ports on all interfaces will be exposed via a Service on it's port (if port < 1000 then port+10000).
If the Service that is now exposed is TCP, it will be also given a HTTPS Ingress endpoint for secure web access.

Examples
- a webserver: a backend listens on port 8080/tcp, a Service is created which references the Environment Pod and the process port and has the ExternalIP of the Instance, an Ingress is created which references the Service and it's port with the addition of the managed instance URL plus TLS
- a UDP game server: a backend listens on 5001/udp, a Services is created which references the Environment Pod and the process port and has the External IP of the Instance 

Due to the wildcard DNS and default DNS setup, a UDP process can also be accessed from INSTANCE.pair.sharing.io:PORT on UDP

The capabilities of providing a locally listening (to the Pair instance) process with an External IP and port as well as an Ingress (if TCP) is managed by Exporter
https://github.com/sharingio/environment/tree/master/cmd/environment-exporter
and Exposer
https://github.com/sharingio/environment/tree/master/cmd/environment-exposer

Therefore, Pair although well tuned and focused on web development, has much greater internet service development capabilities.

Glossary
- Service: https://kubernetes.io/docs/concepts/services-networking/service/
- Instance: a computer managed by Pair
- Ingress: https://kubernetes.io/docs/concepts/services-networking/ingress/